### PR TITLE
Introduce smooth terminator ionosphere

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LMPTools"
 uuid = "9da4b389-a4e8-40b7-9cd7-952b7f4c5d81"
 authors = ["fgasdia <17058025+fgasdia@users.noreply.github.com>"]
-version = "0.0.6"
+version = "0.0.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/plots/plots.jl
+++ b/plots/plots.jl
@@ -123,3 +123,7 @@ heatmap(lons, lats, szas,
 hprimes, betas = flatlinearterminator(szas)
 heatmap(lons, lats, hprimes, color=:amp, clims=(68, 90))
 heatmap(lons, lats, betas, color=:tempo, clims=(0.2, 0.6))
+
+ionos = smoothterminator.(szas)
+heatmap(lons, lats, getindex.(ionos,1), color=:amp, clims=(68, 90))
+heatmap(lons, lats, getindex.(ionos,2), color=:tempo, clims=(0.2, 0.6))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,18 @@ const LON = GROUND_DATA["lon"]
     @test hprimes == hprimes_arr
     @test betas == betas_arr
 
+    h, b = smoothterminator(50)
+    @test h ≈ 74  # hp_day
+    @test b ≈ 0.3  # b_day
+
+    h, b = smoothterminator(130)
+    @test h ≈ 86  # hp_night
+    @test b ≈ 0.5  # b_night
+
+    h, b = smoothterminator(95)
+    @test 74 < h < 86
+    @test 0.3 < b < 0.5
+
     # Sanity tests on fourierperturbation
     coeff = zeros(5)
     pert = fourierperturbation.(szas, (coeff,))


### PR DESCRIPTION
Introduce `smoothterminator` which uses a logistic curve in solar zenith angle between daytime and nighttime ionospheres.